### PR TITLE
Implement ImageSurface.data with Uint8List

### DIFF
--- a/lib/src/cairodart_base.dart
+++ b/lib/src/cairodart_base.dart
@@ -19,6 +19,7 @@ library cairodart.base;
 
 import 'dart-ext:cairodart';
 import 'dart:nativewrappers';
+import 'dart:typed_data';
 
 part 'ref_object.dart';
 part 'context.dart';

--- a/lib/src/surface.dart
+++ b/lib/src/surface.dart
@@ -385,7 +385,7 @@ abstract class _Surface extends NativeFieldWrapperClass2 implements Surface {
 abstract class ImageSurface implements Surface {
 
   factory ImageSurface(Format format, int width, int height) => new _ImageSurface(format, width, height);
-  factory ImageSurface.forData(List<int> data, Format format, int width, int height, int stride) =>
+  factory ImageSurface.forData(Uint8List data, Format format, int width, int height, int stride) =>
     new _ImageSurface.forData(data, format, width, height, stride);
 
   factory ImageSurface.fromPng(String fileName) => new _ImageSurface.fromPng(fileName);
@@ -417,13 +417,13 @@ class _ImageSurface extends _Surface implements ImageSurface {
     _format = format;
   }
 
-  _ImageSurface.forData(List<int> data, Format format, int width, int height, int stride) {
+  _ImageSurface.forData(Uint8List data, Format format, int width, int height, int stride) {
     _createImageSurfaceForData(data, format.value, width, height, stride);
   }
 
   _ImageSurface.internal(){}
 
-  void _createImageSurfaceForData(List<int> data, int format, int width, int height, int stride) native 'image_surface_create_for_data';
+  void _createImageSurfaceForData(Uint8List data, int format, int width, int height, int stride) native 'image_surface_create_for_data';
 
   void _createImageSurface(int format, int width, int height) native 'image_surface_create';
 

--- a/lib/src/surface.dart
+++ b/lib/src/surface.dart
@@ -394,7 +394,7 @@ abstract class ImageSurface implements Surface {
   int get height;
   int get stride;
   Format get format;
-  List<int> get data;
+  Uint8List get data;
 
   void write();
 
@@ -431,7 +431,7 @@ class _ImageSurface extends _Surface implements ImageSurface {
   int get height native 'image_surface_get_height';
   int get stride native 'image_surface_get_stride';
   Format get format => _format;
-  List<int> get data native 'image_surface_get_data';
+  Uint8List get data native 'image_surface_get_data';
 
   String _fileName;
 

--- a/native/surface.c
+++ b/native/surface.c
@@ -97,12 +97,20 @@ void image_surface_get_data(Dart_NativeArguments args) {
     Dart_Handle result = Dart_Null();
 
     if (data) {
-        int length = sizeof(data) / sizeof(data[0]);
-        result = Dart_NewList(length);
-        int i;
-        for (i = 0; i < length; i++) {
-            Dart_ListSetAt(result, i, Dart_NewInteger(data[i]));
-        }
+        // Compute data length, it is not clear what ammount of bytes cairo
+        // uses per pixel but it turns out it's for for both ARGB32 and RGB24.
+        // Reading A1 and A8 formats is a bit more tedious and not yet
+        // implemented here.
+        intptr_t length =
+          cairo_image_surface_get_width(surface) *
+          cairo_image_surface_get_height(surface) * 4;
+
+        // Get surface data.
+        unsigned char *data = cairo_image_surface_get_data(surface);
+
+        // Create Uint8List with surface data.
+        result = Dart_NewTypedData(Dart_TypedData_kUint8, length);
+        Dart_ListSetAsBytes(result, 0, data, length);
     }
 
     Dart_SetReturnValue(args, result);

--- a/native/surface.h
+++ b/native/surface.h
@@ -1,6 +1,7 @@
 #ifndef SURFACE_H
 #define SURFACE_H
 
+#include <string.h>
 #include "dart_api.h"
 
 void surface_destroy(void* handle);

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -20,6 +20,7 @@ library cairodart.test;
 import 'package:cairodart/cairodart.dart';
 import 'package:test/test.dart';
 import 'dart:core' hide Pattern;
+import 'dart:typed_data';
 
 part 'surface_test.dart';
 part 'format_test.dart';

--- a/test/surface_test.dart
+++ b/test/surface_test.dart
@@ -31,7 +31,7 @@ runSurfaceTests() {
     test('should correctly get/set device offset', () {
       var surface = new ImageSurface(Format.ARGB32, 640, 480);
       surface.deviceOffset = new Point.from(20.0, 25.0);
-      
+
       Point offset = surface.deviceOffset;
       expect(offset.x, equals(20.0));
       expect(offset.y, equals(25.0));
@@ -48,7 +48,7 @@ runSurfaceTests() {
     test('should correctly get/set fallback resolution', () {
       var surface = new ImageSurface(Format.ARGB32, 640, 480);
       surface.fallbackResolution = new Resolution(250.0, 120.0);
-      
+
       expect(surface.fallbackResolution.xResolution, equals(250.0));
       expect(surface.fallbackResolution.yResolution, equals(120.0));
     });
@@ -75,10 +75,11 @@ runSurfaceTests() {
       expect(surface.surfaceType, equals(SurfaceType.Image));
     });
     test('should correctly get/set data byte array', () {
-      List<int> data = new List<int>.from([30,40,50,60,70,80,90,100]);
-      var surface = new ImageSurface.forData(data, Format.ARGB32, 640, 480, Format.ARGB32.strideForWidth(640));
+      final data = new Uint8List.fromList([0, 0, 0, 255]);
+      final surface = new ImageSurface.forData(
+        data, Format.ARGB32, 1, 1, Format.ARGB32.strideForWidth(1));
 
-      List<int> imgData = surface.data;
+      Uint8List imgData = surface.data;
       expect(imgData, equals(data));
     });
   });


### PR DESCRIPTION
Use `Uint8List` for various reasons, not only time and space complexity in Dart. The internal data pointer can also be acquired in other native code, like my FLTK extension where I can pass the internal `uint8_t*` array directly to the pixel draw function. Also, most other Dart libraries use `TypedData` for storing large chunks of binary data (e.g. `image`).

It might be a good idea to also use `Uint8List` for the `ImageSurface.forData` constructor, although both things are isolated since there is currently no way to keep track of the `forData` data pointer.

I tested this by drawing the pixel data to the screen which seems to work, at least with `ARGB32` and `RGB24`. I'm not sure how Cairo stores `A1` formats etc. but this is at least a start. (at least this is enough to enable me to use cairodart in my `CairoSurface` UI widget :D)
